### PR TITLE
Feat/login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Temporary Items
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+*.xcconfig
 
 ## User settings
 xcuserdata/

--- a/Plugins/FullCar/ProjectDescriptionHelpers/Configuration+.swift
+++ b/Plugins/FullCar/ProjectDescriptionHelpers/Configuration+.swift
@@ -27,7 +27,8 @@ public extension [Configuration] {
 //                "PROVISIONING_PROFILE_SPECIFIER": "FullCar Development",
 //                // 아직 없는데 추가해야하는 아이들
 //                "APP_UNIVERSAL_LINKS": "",
-            ]
+            ],
+            xcconfig: .relativeToRoot("Targets/FullCar/Resources/APIKeys.xcconfig")
         ),
         .release(
             name: .store,
@@ -47,7 +48,8 @@ public extension [Configuration] {
 //                "PROVISIONING_PROFILE_SPECIFIER": "FullCar Distribution",
 //                /// 아직 없는데 추가해야하는 아이들
 //                "APP_UNIVERSAL_LINKS": "",
-            ]
+            ],
+            xcconfig: .relativeToRoot("Targets/FullCar/Resources/APIKeys.xcconfig")
         )
     ]
 }

--- a/Plugins/FullCar/ProjectDescriptionHelpers/Dependencies.swift
+++ b/Plugins/FullCar/ProjectDescriptionHelpers/Dependencies.swift
@@ -19,10 +19,14 @@ public extension TargetDependency {
     static let alamofire: TargetDependency = .external(name: "Alamofire")
     static let crashlytics: TargetDependency = .external(name: "FirebaseCrashlytics")
     static let analytics: TargetDependency = .external(name: "FirebaseAnalytics")
+    static let kakaoAuth: TargetDependency = .external(name: "KakaoSDKAuth")
+    static let kakaoCommon: TargetDependency = .external(name: "KakaoSDKCommon")
+    static let kakaoUser: TargetDependency = .external(name: "KakaoSDKUser")
 }
 
 public extension Package {
     static let firebase: Self = .package(url: "https://github.com/firebase/firebase-ios-sdk", .upToNextMajor(from: "10.19.0"))
     static let dependencies: Self = .package(url: "https://github.com/pointfreeco/swift-dependencies", .upToNextMajor(from: "1.1.2"))
     static let alamofire: Self = .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.8.1"))
+    static let kakao: Self = .package(url: "https://github.com/kakao/kakao-ios-sdk", .upToNextMajor(from: "2.19.0"))
 }

--- a/Plugins/FullCar/ProjectDescriptionHelpers/FullCar.swift
+++ b/Plugins/FullCar/ProjectDescriptionHelpers/FullCar.swift
@@ -19,7 +19,18 @@ public let mainTarget: Target = .init(
             "CFBundleShortVersionString": "1.0",
             "CFBundleVersion": "1",
             "UIMainStoryboardFile": "",
-            "UILaunchStoryboardName": "LaunchScreen"
+            "UILaunchStoryboardName": "LaunchScreen",
+            "LSApplicationQueriesSchemes": [
+              "kakaokompassauth",
+              "kakaolink"
+            ],
+            "KakaoNativeAppKey": "$(KAKAO_NATIVE_APP_KEY)",
+            "CFBundleURLTypes": [
+              [
+                "CFBundleTypeRole": "Editor",
+                "CFBundleURLSchemes": ["kakao$(KAKAO_NATIVE_APP_KEY)"]
+              ]
+            ],
         ]
     ),
     sources: ["Sources/**"],

--- a/Plugins/FullCar/ProjectDescriptionHelpers/FullCar.swift
+++ b/Plugins/FullCar/ProjectDescriptionHelpers/FullCar.swift
@@ -27,5 +27,8 @@ public let mainTarget: Target = .init(
     dependencies: [
         .fullCarKit,
         .fullCarUI,
+        .kakaoAuth,
+        .kakaoCommon,
+        .kakaoUser
     ]
 )

--- a/Targets/FullCar/Sources/Extensions/Bundle+.swift
+++ b/Targets/FullCar/Sources/Extensions/Bundle+.swift
@@ -1,0 +1,22 @@
+//
+//  Bundle+.swift
+//  FullCar
+//
+//  Created by Sunny on 12/18/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+extension Bundle {
+
+    var kakaoNativeAppKey: String? {
+        guard let file = self.path(forResource: "Info", ofType: "plist"),
+              let resource = NSDictionary(contentsOfFile: file),
+              let key = resource["KakaoNativeAppKey"] as? String else {
+            return nil
+        }
+        
+        return key
+    }
+}

--- a/Targets/FullCar/Sources/FullCarApp.swift
+++ b/Targets/FullCar/Sources/FullCarApp.swift
@@ -22,7 +22,7 @@ struct FullCarApp: App {
     }
 
     private func setupKakaoSDK() {
-//        guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
-//        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
+        guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
+        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }
 }

--- a/Targets/FullCar/Sources/FullCarApp.swift
+++ b/Targets/FullCar/Sources/FullCarApp.swift
@@ -1,28 +1,12 @@
 import SwiftUI
 import FullCarUI
-import KakaoSDKAuth
-import KakaoSDKCommon
 
 @main
 struct FullCarApp: App {
 
-    init() {
-        setupKakaoSDK()
-    }
-    
     var body: some Scene {
         WindowGroup {
             RootView(viewModel: .init())
-                .onOpenURL { url in
-                    if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                        _ = AuthController.handleOpenUrl(url: url)
-                    }
-                }
         }
-    }
-
-    private func setupKakaoSDK() {
-        guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
-        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }
 }

--- a/Targets/FullCar/Sources/FullCarApp.swift
+++ b/Targets/FullCar/Sources/FullCarApp.swift
@@ -1,11 +1,28 @@
 import SwiftUI
 import FullCarUI
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 @main
 struct FullCarApp: App {
+
+    init() {
+        setupKakaoSDK()
+    }
+    
     var body: some Scene {
         WindowGroup {
             RootView(viewModel: .init())
+                .onOpenURL { url in
+                    if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                        _ = AuthController.handleOpenUrl(url: url)
+                    }
+                }
         }
+    }
+
+    private func setupKakaoSDK() {
+//        guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
+//        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }
 }

--- a/Targets/FullCar/Sources/Home/API.swift
+++ b/Targets/FullCar/Sources/Home/API.swift
@@ -1,0 +1,44 @@
+//
+//  API.swift
+//  FullCar
+//
+//  Created by 한상진 on 12/18/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+import FullCarKit
+import Dependencies
+
+struct Home {
+    struct API { 
+        private var fetch: @Sendable (String, String) async throws -> Model.Response
+        
+        func fetch(id: String, name: String) async throws -> Model.Response {
+            return try await self.fetch(id, name)
+        }
+    }
+    
+    struct Model {
+        struct Response: Decodable {
+            let result: String
+        }
+    }
+}
+
+extension Home.API: DependencyKey {
+    static let liveValue: Home.API = .init(
+        fetch: { id, name in
+            return try await NetworkClient.main
+                .request(endpoint: Endpoint.Home.fetch(id: id, name: name))
+                .response()
+        }
+    )
+}
+
+extension DependencyValues {
+    var homeAPI: Home.API {
+        get { self[Home.API.self] }
+        set { self[Home.API.self] = newValue }
+    }
+}

--- a/Targets/FullCar/Sources/Home/Home.swift
+++ b/Targets/FullCar/Sources/Home/Home.swift
@@ -7,12 +7,24 @@
 //
 
 import SwiftUI
+import FullCarKit
 import Observation
+import Dependencies
 
 @MainActor
 @Observable
 final class HomeViewModel {
+    @ObservationIgnored
+    @Dependency(\.homeAPI) private var homeAPI
     
+    func fetchHome() async {
+        do {
+            let response = try await homeAPI.fetch(id: "id", name: "name")
+        }
+        catch {
+            // some error handling
+        }
+    }
 } 
 
 struct HomeView: View {

--- a/Targets/FullCar/Sources/Login/FullCarAccount.swift
+++ b/Targets/FullCar/Sources/Login/FullCarAccount.swift
@@ -1,5 +1,5 @@
 //
-//  Login.swift
+//  FullCarAccount.swift
 //  FullCar
 //
 //  Created by Sunny on 12/17/23.
@@ -13,7 +13,7 @@ import KakaoSDKUser
 import AuthenticationServices
 import Dependencies
 
-struct Login {
+struct FullCarAccount {
     @Dependency(\.accountService.login) var login
 
     func kakaoLogin(completion: @escaping () -> Void) async {
@@ -67,7 +67,7 @@ struct Login {
     }
 }
 
-extension Login {
+extension FullCarAccount {
     enum LoginType: String {
         case kakao
         case apple
@@ -79,12 +79,12 @@ extension Login {
 }
 
 extension DependencyValues {
-    var login: Login {
-        get { self[Login.self] }
-        set { self[Login.self] = newValue }
+    var fullCarAccount: FullCarAccount {
+        get { self[FullCarAccount.self] }
+        set { self[FullCarAccount.self] = newValue }
     }
 }
 
-extension Login: DependencyKey {
-    static var liveValue: Login = .init()
+extension FullCarAccount: DependencyKey {
+    static var liveValue: FullCarAccount = .init()
 }

--- a/Targets/FullCar/Sources/Login/FullCarAccount.swift
+++ b/Targets/FullCar/Sources/Login/FullCarAccount.swift
@@ -76,13 +76,13 @@ extension FullCarAccount {
     }
 }
 
+extension FullCarAccount: DependencyKey {
+    static var liveValue: FullCarAccount = .init()
+}
+
 extension DependencyValues {
     var fullCarAccount: FullCarAccount {
         get { self[FullCarAccount.self] }
         set { self[FullCarAccount.self] = newValue }
     }
-}
-
-extension FullCarAccount: DependencyKey {
-    static var liveValue: FullCarAccount = .init()
 }

--- a/Targets/FullCar/Sources/Login/FullCarAccount.swift
+++ b/Targets/FullCar/Sources/Login/FullCarAccount.swift
@@ -25,24 +25,20 @@ final class FullCarAccount {
                 authenticateWithKakao()
                 self.continuation = continuation
             }
-            try login(accessToken)
+            try await login(accessToken)
         } else {
             throw LoginError.continuationAlreadySet
         }
     }
 
-    func appleLogin(result: Result<ASAuthorization, Error>, completion: @escaping () -> Void) {
+    func appleLogin(result: Result<ASAuthorization, Error>) async throws {
         if case let .success(authorization) = result {
-            do {
-                guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                      let identityToken = credential.identityToken,
-                      let token = String(data: identityToken, encoding: .utf8) else { return }
-                try login(token)
-
-                completion()
-            } catch {
-                print(error)
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                  let identityToken = credential.identityToken,
+                  let token = String(data: identityToken, encoding: .utf8) else {
+                throw LoginError.appleTokenNil
             }
+            try await login(token)
         }
     }
 
@@ -75,6 +71,7 @@ extension FullCarAccount {
 
     enum LoginError: Error {
         case kakaoTokenNil
+        case appleTokenNil
         case continuationAlreadySet
     }
 }

--- a/Targets/FullCar/Sources/Login/FullCarAccount.swift
+++ b/Targets/FullCar/Sources/Login/FullCarAccount.swift
@@ -26,6 +26,8 @@ final class FullCarAccount {
                 self.continuation = continuation
             }
             try await login(accessToken)
+
+            self.continuation = nil
         } else {
             throw LoginError.continuationAlreadySet
         }

--- a/Targets/FullCar/Sources/Login/Login.swift
+++ b/Targets/FullCar/Sources/Login/Login.swift
@@ -1,0 +1,90 @@
+//
+//  Login.swift
+//  FullCar
+//
+//  Created by Sunny on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
+import AuthenticationServices
+import Dependencies
+
+struct Login {
+    @Dependency(\.accountService) var account
+
+    func kakaoLogin(completion: @escaping () -> Void) async {
+        do {
+            let accessToken = try await self.authenticateWithKakao()
+            try account.login(accessToken: accessToken)
+            
+            completion()
+        } catch {
+            print(error)
+        }
+    }
+
+    func appleLogin(result: Result<ASAuthorization, Error>, completion: @escaping () -> Void) {
+        if case let .success(authorization) = result {
+            do {
+                guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                      let identityToken = credential.identityToken,
+                      let token = String(data: identityToken, encoding: .utf8) else { return }
+                try account.login(accessToken: token)
+
+                completion()
+            } catch {
+                print(error)
+            }
+        }
+    }
+
+    private func authenticateWithKakao() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            let completion: ((OAuthToken?, Error?) -> Void) = { token, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    guard let accessToken = token?.accessToken else {
+                        continuation.resume(throwing: LoginError.kakaoTokenNil)
+                        return
+                    }
+                    continuation.resume(returning: accessToken)
+                }
+            }
+
+            DispatchQueue.main.async {
+                if UserApi.isKakaoTalkLoginAvailable() {
+                    UserApi.shared.loginWithKakaoTalk(completion: completion)
+                } else {
+                    UserApi.shared.loginWithKakaoAccount(completion: completion)
+                }
+            }
+        }
+    }
+}
+
+extension Login {
+    enum LoginType: String {
+        case kakao
+        case apple
+    }
+
+    enum LoginError: Error {
+        case kakaoTokenNil
+    }
+}
+
+extension DependencyValues {
+    var login: Login {
+        get { self[Login.self] }
+        set { self[Login.self] = newValue }
+    }
+}
+
+extension Login: DependencyKey {
+    static var liveValue: Login = .init()
+}

--- a/Targets/FullCar/Sources/Login/Login.swift
+++ b/Targets/FullCar/Sources/Login/Login.swift
@@ -14,12 +14,12 @@ import AuthenticationServices
 import Dependencies
 
 struct Login {
-    @Dependency(\.accountService) var account
+    @Dependency(\.accountService.login) var login
 
     func kakaoLogin(completion: @escaping () -> Void) async {
         do {
             let accessToken = try await self.authenticateWithKakao()
-            try account.login(accessToken: accessToken)
+            try login(accessToken)
             
             completion()
         } catch {
@@ -33,7 +33,7 @@ struct Login {
                 guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
                       let identityToken = credential.identityToken,
                       let token = String(data: identityToken, encoding: .utf8) else { return }
-                try account.login(accessToken: token)
+                try login(token)
 
                 completion()
             } catch {

--- a/Targets/FullCar/Sources/Login/LoginView.swift
+++ b/Targets/FullCar/Sources/Login/LoginView.swift
@@ -14,7 +14,6 @@ import AuthenticationServices
 @MainActor
 @Observable
 final class LoginViewModel {
-
     @ObservationIgnored @Dependency(\.login) var login
 
     let fullCar = FullCar.shared

--- a/Targets/FullCar/Sources/Login/LoginView.swift
+++ b/Targets/FullCar/Sources/Login/LoginView.swift
@@ -28,9 +28,13 @@ final class LoginViewModel {
         }
     }
 
-    func appleLoginButtonTapped(result: Result<ASAuthorization, Error>) {
-        account.appleLogin(result: result) {
+    func appleLoginButtonTapped(result: Result<ASAuthorization, Error>) async {
+        do {
+            try await account.appleLogin(result: result)
             self.fullCar.appState = .tab
+        } catch {
+            self.fullCar.appState = .login
+            print(error)
         }
     }
 }

--- a/Targets/FullCar/Sources/Login/LoginView.swift
+++ b/Targets/FullCar/Sources/Login/LoginView.swift
@@ -19,8 +19,12 @@ final class LoginViewModel {
     let fullCar = FullCar.shared
 
     func kakaoLoginButtonTapped() async {
-        await account.kakaoLogin() {
+        do {
+            try await account.kakaoLogin()
             self.fullCar.appState = .tab
+        } catch {
+            self.fullCar.appState = .login
+            print(error)
         }
     }
 

--- a/Targets/FullCar/Sources/Login/LoginView.swift
+++ b/Targets/FullCar/Sources/Login/LoginView.swift
@@ -14,18 +14,18 @@ import AuthenticationServices
 @MainActor
 @Observable
 final class LoginViewModel {
-    @ObservationIgnored @Dependency(\.login) var login
+    @ObservationIgnored @Dependency(\.fullCarAccount) var account
 
     let fullCar = FullCar.shared
 
     func kakaoLoginButtonTapped() async {
-        await login.kakaoLogin() {
+        await account.kakaoLogin() {
             self.fullCar.appState = .tab
         }
     }
 
     func appleLoginButtonTapped(result: Result<ASAuthorization, Error>) {
-        login.appleLogin(result: result) {
+        account.appleLogin(result: result) {
             self.fullCar.appState = .tab
         }
     }

--- a/Targets/FullCar/Sources/Login/LoginView.swift
+++ b/Targets/FullCar/Sources/Login/LoginView.swift
@@ -17,17 +17,17 @@ final class LoginViewModel {
 
     @ObservationIgnored @Dependency(\.login) var login
 
-    var appState: FullCar.State = FullCar.shared.appState
+    let fullCar = FullCar.shared
 
     func kakaoLoginButtonTapped() async {
         await login.kakaoLogin() {
-            self.appState = .tab
+            self.fullCar.appState = .tab
         }
     }
 
     func appleLoginButtonTapped(result: Result<ASAuthorization, Error>) {
         login.appleLogin(result: result) {
-            self.appState = .tab
+            self.fullCar.appState = .tab
         }
     }
 }
@@ -43,6 +43,8 @@ struct LoginView: View {
         VStack {
             kakaoLoginButton
             appleLoginButton
+                // 임시 크기 설정
+                .frame(height: 50)
         }
     }
     

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -25,7 +25,7 @@ final class RootViewModel {
     // 토큰이 없으면 로그인 화면으로
     func onFirstTask() async {
         try? await Task.sleep(for: .seconds(1))
-        if account.hasValidToken {
+        if account.hasValidToken() {
             appState = .tab
         } else {
             appState = .login

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -27,7 +27,7 @@ final class RootViewModel {
     // 토큰이 없으면 로그인 화면으로
     func onFirstTask() async {
         try? await Task.sleep(for: .seconds(1))
-        if account.hasValidToken() {
+        if await account.hasValidToken() {
             appState = .tab
         } else {
             appState = .login

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -27,7 +27,7 @@ final class RootViewModel {
     // 토큰이 없으면 로그인 화면으로
     func onFirstTask() async {
         try? await Task.sleep(for: .seconds(1))
-        if await account.hasValidToken() {
+        if ((try? await account.hasValidToken()) != nil) {
             appState = .tab
         } else {
             appState = .login
@@ -69,8 +69,13 @@ struct RootView: View {
 //            Image("런치스크린 이미지 나오면!", bundle: .main)
                 
         case .login:
-            LoginView(viewModel: .init())
-            
+            LoginView(
+                viewModel: withDependencies({
+                    $0.accountService = .testValue
+                }, operation: {
+                    LoginViewModel()
+                })
+            )
         case .tab:
             FullCarTabView(viewModel: .init())
         }

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -11,6 +11,8 @@ import FullCarUI
 import FullCarKit
 import Observation
 import Dependencies
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 @MainActor
 @Observable
@@ -31,6 +33,11 @@ final class RootViewModel {
             appState = .login
         }
     }
+
+    func setupKakaoSDK() async {
+        guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
+        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
+    }
 }
 
 struct RootView: View {
@@ -38,7 +45,15 @@ struct RootView: View {
     
     var body: some View {
         bodyView
-            .onFirstTask { await viewModel.onFirstTask() }
+            .onOpenURL { url in
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
+            }
+            .onFirstTask {
+                await viewModel.setupKakaoSDK()
+                await viewModel.onFirstTask()
+            }
     }
     
     @MainActor

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -15,7 +15,6 @@ import Dependencies
 @MainActor
 @Observable
 final class RootViewModel {
-
     @ObservationIgnored @Dependency(\.accountService) private var account
 
     var appState: FullCar.State = FullCar.shared.appState
@@ -35,7 +34,6 @@ final class RootViewModel {
 }
 
 struct RootView: View {
-    
     let viewModel: RootViewModel
     
     var body: some View {

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -10,10 +10,14 @@ import SwiftUI
 import FullCarUI
 import FullCarKit
 import Observation
+import Dependencies
 
 @MainActor
 @Observable
 final class RootViewModel {
+
+    @ObservationIgnored @Dependency(\.accountService) private var account
+
     var appState: FullCar.State = FullCar.shared.appState
 
     // 자동로그인 시도
@@ -22,7 +26,7 @@ final class RootViewModel {
     // 토큰이 없으면 로그인 화면으로
     func onFirstTask() async {
         try? await Task.sleep(for: .seconds(1))
-        if true {
+        if account.hasValidToken {
             appState = .tab
         } else {
             appState = .login

--- a/Targets/FullCar/Sources/Root/RootView.swift
+++ b/Targets/FullCar/Sources/Root/RootView.swift
@@ -38,6 +38,12 @@ final class RootViewModel {
         guard let kakaoNativeAppKey = Bundle.main.kakaoNativeAppKey else { return }
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }
+
+    func handleKakaoURL(_ url: URL) {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            _ = AuthController.handleOpenUrl(url: url)
+        }
+    }
 }
 
 struct RootView: View {
@@ -46,9 +52,7 @@ struct RootView: View {
     var body: some View {
         bodyView
             .onOpenURL { url in
-                if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                    _ = AuthController.handleOpenUrl(url: url)
-                }
+                viewModel.handleKakaoURL(url)
             }
             .onFirstTask {
                 await viewModel.setupKakaoSDK()

--- a/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
+++ b/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
@@ -1,0 +1,33 @@
+//
+//  AccountAPI.swift
+//  FullCarKit
+//
+//  Created by Sunny on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+struct AccountAPI {
+    func login(accessToken: String) -> Result<String, Error> {
+        // 네트워크 통신
+        let response = Result<String, Error>.success("account token 발급 완료")
+        return response
+    }
+
+    func logout() { }
+
+    func leave() { }
+}
+
+extension DependencyValues {
+    var accountAPI: AccountAPI {
+        get { self[AccountAPI.self] }
+        set { self[AccountAPI.self] = newValue }
+    }
+}
+
+extension AccountAPI: DependencyKey {
+    static let liveValue: AccountAPI = .init()
+}

--- a/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
+++ b/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
@@ -13,6 +13,7 @@ struct AccountAPI {
     var login: (_ accessToken: String) -> Result<String, Error>
     var logout: () -> Void
     var leave: () -> Void
+    var refresh: (_ accessToken: String, _ refreshToken: String) -> Result<String, Error>
 }
 
 extension AccountAPI: DependencyKey {
@@ -24,8 +25,11 @@ extension AccountAPI: DependencyKey {
                 return response
             },
             logout: { },
-            leave: { }
-        )
+            leave: { },
+            refresh: { accessToken, refreshToken in
+                let response = Result<String, Error>.success("access token 재발급 완료")
+                return response
+            })
     }
 }
 

--- a/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
+++ b/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
@@ -13,7 +13,7 @@ struct AccountAPI {
     var login: (_ accessToken: String) -> Result<String, Error>
     var logout: () -> Void
     var leave: () -> Void
-    var refresh: (_ accessToken: String, _ refreshToken: String) -> Result<String, Error>
+    var refresh: (_ refreshToken: String) async throws -> AccountCredential
 }
 
 extension AccountAPI: DependencyKey {

--- a/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
+++ b/Targets/FullCarKit/Sources/Account/API/AccountAPI.swift
@@ -10,15 +10,23 @@ import Foundation
 import Dependencies
 
 struct AccountAPI {
-    func login(accessToken: String) -> Result<String, Error> {
-        // 네트워크 통신
-        let response = Result<String, Error>.success("account token 발급 완료")
-        return response
+    var login: (_ accessToken: String) -> Result<String, Error>
+    var logout: () -> Void
+    var leave: () -> Void
+}
+
+extension AccountAPI: DependencyKey {
+    static var liveValue: AccountAPI {
+        return  AccountAPI(
+            login: { accessToken in
+                // 추후 네트워크 통신 부분
+                let response = Result<String, Error>.success("account token 발급 완료")
+                return response
+            },
+            logout: { },
+            leave: { }
+        )
     }
-
-    func logout() { }
-
-    func leave() { }
 }
 
 extension DependencyValues {
@@ -26,8 +34,4 @@ extension DependencyValues {
         get { self[AccountAPI.self] }
         set { self[AccountAPI.self] = newValue }
     }
-}
-
-extension AccountAPI: DependencyKey {
-    static let liveValue: AccountAPI = .init()
 }

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -1,0 +1,57 @@
+//
+//  AccountService.swift
+//  FullCarKit
+//
+//  Created by Sunny on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public struct AccountService {
+
+    @Dependency(\.accountAPI) var api
+    @Dependency(\.tokenStorage) var tokenStorage
+
+    public var hasValidToken: Bool {
+        guard let credential = tokenStorage.loadToken() else { return false }
+        return credential.authTokenExpiration > Date()
+    }
+
+    public func login(accessToken: String) throws {
+        let response = api.login(accessToken: accessToken)
+
+        // 서버에서 받아온 account token 저장
+        switch response {
+        case .success(let token):
+            let credential = AccountCredential(
+                authToken: token,
+                authTokenExpiration: Date()
+            )
+            tokenStorage.save(token: credential)
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    public func logout() {
+        api.logout()
+    }
+
+    public func leave() {
+        api.leave()
+        tokenStorage.deleteToken()
+    }
+}
+
+extension DependencyValues {
+    public var accountService: AccountService {
+        get { self[AccountService.self] }
+        set { self[AccountService.self] = newValue }
+    }
+}
+
+extension AccountService: DependencyKey {
+    public static var liveValue: AccountService = .init()
+}

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -10,7 +10,7 @@ import Foundation
 import Dependencies
 
 public struct AccountService {
-    public var hasValidToken: () async -> Bool
+    public var hasValidToken: () async throws -> Bool
     public var login: (_ accessToken: String) async throws -> Void
     public var logout: () -> Void
     public var leave: () async -> Void
@@ -24,7 +24,7 @@ extension AccountService: DependencyKey {
 
         return AccountService(
             hasValidToken: {
-                guard let credential = await tokenStorage.loadToken() else { return false }
+                let credential = try await tokenStorage.loadToken()
                 return credential.accessTokenExpiration > Date()
             },
             login: { accessToken in

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -43,6 +43,28 @@ extension AccountService: DependencyKey {
     }
 }
 
+extension AccountService: TestDependencyKey {
+    static public var testValue: AccountService {
+        @Dependency(\.accountAPI) var api
+
+        return AccountService(
+            hasValidToken: { return false },
+            login: { accessToken in
+                // 실제 서버 통신 대신 목데이터 사용
+                let credential = AccountCredential(
+                    accessToken: "access Token",
+                    refreshToken: "refresh Token",
+                    accessTokenExpiration: Date()
+                )
+
+                print("test/ login credential: \(credential)")
+            },
+            logout: { },
+            leave: { }
+        )
+    }
+}
+
 extension DependencyValues {
     public var accountService: AccountService {
         get { self[AccountService.self] }

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -10,7 +10,6 @@ import Foundation
 import Dependencies
 
 public struct AccountService {
-
     @Dependency(\.accountAPI) var api
     @Dependency(\.tokenStorage) var tokenStorage
 
@@ -22,9 +21,9 @@ public struct AccountService {
     public func login(accessToken: String) throws {
         let response = api.login(accessToken: accessToken)
 
-        // 서버에서 받아온 account token 저장
         switch response {
         case .success(let token):
+            // 서버에서 받아온 account token과 유효기간 저장
             let credential = AccountCredential(
                 authToken: token,
                 authTokenExpiration: Date()

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -19,7 +19,7 @@ public struct AccountService {
     }
 
     public func login(accessToken: String) throws {
-        let response = api.login(accessToken: accessToken)
+        let response = api.login(accessToken)
 
         switch response {
         case .success(let token):

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -27,13 +27,8 @@ extension AccountService: DependencyKey {
                 return credential.accessTokenExpiration > Date()
             },
             login: { accessToken in
-                let token = try await api.login(accessToken)
+                let credential = try await api.login(accessToken)
 
-                let credential = AccountCredential(
-                    accessToken: token,
-                    refreshToken: "refresh Token",
-                    accessTokenExpiration: Date()
-                )
                 await tokenStorage.save(token: credential)
             },
             logout: {

--- a/Targets/FullCarKit/Sources/Account/AccountService.swift
+++ b/Targets/FullCarKit/Sources/Account/AccountService.swift
@@ -10,37 +10,45 @@ import Foundation
 import Dependencies
 
 public struct AccountService {
-    @Dependency(\.accountAPI) var api
-    @Dependency(\.tokenStorage) var tokenStorage
+    public var hasValidToken: () -> Bool
+    public var login: (_ accessToken: String) throws -> Void
+    public var logout: () -> Void
+    public var leave: () -> Void
+}
 
-    public var hasValidToken: Bool {
-        guard let credential = tokenStorage.loadToken() else { return false }
-        return credential.authTokenExpiration > Date()
-    }
+extension AccountService: DependencyKey {
+    public static var liveValue: AccountService {
+        @Dependency(\.accountAPI) var api
+        @Dependency(\.tokenStorage) var tokenStorage
 
-    public func login(accessToken: String) throws {
-        let response = api.login(accessToken)
+        return AccountService(
+            hasValidToken: {
+                guard let credential = tokenStorage.loadToken() else { return false }
+                return credential.authTokenExpiration > Date()
+            },
+            login: { accessToken in
+                let response = api.login(accessToken)
 
-        switch response {
-        case .success(let token):
-            // 서버에서 받아온 account token과 유효기간 저장
-            let credential = AccountCredential(
-                authToken: token,
-                authTokenExpiration: Date()
-            )
-            tokenStorage.save(token: credential)
-        case .failure(let error):
-            throw error
-        }
-    }
-
-    public func logout() {
-        api.logout()
-    }
-
-    public func leave() {
-        api.leave()
-        tokenStorage.deleteToken()
+                switch response {
+                case .success(let token):
+                    // 서버에서 받아온 account token과 유효기간 저장
+                    let credential = AccountCredential(
+                        authToken: token,
+                        authTokenExpiration: Date()
+                    )
+                    tokenStorage.save(token: credential)
+                case .failure(let error):
+                    throw error
+                }
+            },
+            logout: {
+                api.logout()
+            },
+            leave: {
+                api.leave()
+                tokenStorage.deleteToken()
+            }
+        )
     }
 }
 
@@ -49,8 +57,4 @@ extension DependencyValues {
         get { self[AccountService.self] }
         set { self[AccountService.self] = newValue }
     }
-}
-
-extension AccountService: DependencyKey {
-    public static var liveValue: AccountService = .init()
 }

--- a/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
+++ b/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 struct AccountCredential: Codable {
-    var authToken: String
-    var authTokenExpiration: Date
+    let authToken: String
+    let authTokenExpiration: Date
 }

--- a/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
+++ b/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
@@ -1,0 +1,14 @@
+//
+//  AccountCredential.swift
+//  FullCarKit
+//
+//  Created by Sunny on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+struct AccountCredential: Codable {
+    var authToken: String
+    var authTokenExpiration: Date
+}

--- a/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
+++ b/Targets/FullCarKit/Sources/Account/Model/AccountCredential.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct AccountCredential: Codable {
-    let authToken: String
-    let authTokenExpiration: Date
+    let accessToken: String
+    let refreshToken: String
+    let accessTokenExpiration: Date
 }

--- a/Targets/FullCarKit/Sources/KeyChain.swift
+++ b/Targets/FullCarKit/Sources/KeyChain.swift
@@ -18,7 +18,7 @@ public class Keychain {
     private init() {}
     
     private func getPrefixedKey(key: String) -> String {
-        return "com.havi.DayRoom.\(key)"
+        return "com.fullcar.app.\(key)"
     }
     
     private func toString(_ value: CFString) -> String {

--- a/Targets/FullCarKit/Sources/Network/DataRequest.swift
+++ b/Targets/FullCarKit/Sources/Network/DataRequest.swift
@@ -31,13 +31,19 @@ public final class DataRequest: NetworkRequestable {
     
     @MainActor
     public func response<Model: Decodable>(with decoder: JSONDecoder = .init()) async throws -> Model {
-        let response = try await response()
+        let response = try await fetchResponse()
         try self.validate(response: response)
         let result: Model = try self.decode(with: decoder, response: response)
         return result
     }
-    
-    private func response() async throws -> NetworkResponse {
+
+    @MainActor
+    public func response() async throws {
+        let response = try await fetchResponse()
+        try self.validate(response: response)
+    }
+
+    private func fetchResponse() async throws -> NetworkResponse {
         let initialRequest = try endpoint.asURLRequest()
         let urlRequest = try await adapt(request: initialRequest)
         let response = try await dataTask(with: urlRequest)

--- a/Targets/FullCarKit/Sources/Network/DataRequest.swift
+++ b/Targets/FullCarKit/Sources/Network/DataRequest.swift
@@ -1,0 +1,56 @@
+//
+//  DataRequest.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public final class DataRequest: NetworkRequestable {
+    public let session: URLSession
+    public let task: URLSessionTask?
+    public let endpoint: URLRequestConfigurable
+    public let options: NetworkRequestOptions
+    public let interceptors: [NetworkInterceptor]
+    
+    public init(
+        session: URLSession,
+        task: URLSessionTask? = nil,
+        endpoint: URLRequestConfigurable,
+        options: NetworkRequestOptions = .all,
+        interceptors: [NetworkInterceptor]
+    ) {
+        self.session = session
+        self.task = task
+        self.endpoint = endpoint
+        self.options = options
+        self.interceptors = interceptors
+    }
+    
+    @MainActor
+    public func response<Model: Decodable>(with decoder: JSONDecoder = .init()) async throws -> Model {
+        let response = try await response()
+        try self.validate(response: response)
+        let result: Model = try self.decode(with: decoder, response: response)
+        return result
+    }
+    
+    private func response() async throws -> NetworkResponse {
+        let initialRequest = try endpoint.asURLRequest()
+        let urlRequest = try await adapt(request: initialRequest)
+        let response = try await dataTask(with: urlRequest)
+        return response
+    }
+    
+    private func dataTask(with urlRequest: URLRequest) async throws -> NetworkResponse {
+        do {
+            let (data, response) = try await session.data(for: urlRequest)
+            return NetworkResponse(data: data, response: response, error: nil)
+        }
+        catch {
+            return NetworkResponse(data: nil, response: nil, error: error)
+        }
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/Header.swift
+++ b/Targets/FullCarKit/Sources/Network/Header.swift
@@ -1,0 +1,54 @@
+//
+//  Header.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public struct Header: Hashable {
+    public let key: String
+    public let value: String
+    
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}
+
+public extension Header {
+    var toDictionary: String {
+        return "\(key): \(value)" 
+    }
+}
+
+public extension Header {
+    static func authorization(_ value: String) -> Header {
+        return Header(key: "Authorization", value: value)
+    }
+    static func contentType(value: String) -> Header {
+        return Header(key: "Content-Type", value: value)
+    }
+    static func userAgent(value: String) -> Header {
+        return Header(key: "User-Agent", value: value)
+    }
+}
+
+public extension [Header] {
+    var dictionary: [String: String] {
+        let namesAndValues = self.map { ($0.key, $0.value) }
+        return Dictionary(namesAndValues, uniquingKeysWith: { _, last in last })
+    }
+}
+
+public extension URLRequest {
+    mutating func setHeaders( _ headers: [Header]) {
+        headers.forEach { self.setHeader($0) }
+    }
+    
+    mutating func setHeader( _ header: Header) {
+        self.setValue(header.value, forHTTPHeaderField: header.key)
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/Interceptor.swift
+++ b/Targets/FullCarKit/Sources/Network/Interceptor.swift
@@ -1,0 +1,20 @@
+//
+//  Interceptor.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public protocol NetworkInterceptor {
+    func adapt(urlRequest: URLRequest, options: NetworkRequestOptions) async throws -> URLRequest
+    func retry(
+        urlRequest: URLRequest, 
+        response: URLResponse?,
+        data: Data?, 
+        with error: Error, 
+        options: NetworkRequestOptions
+    ) async -> (URLRequest, RetryResult)
+}

--- a/Targets/FullCarKit/Sources/Network/Method.swift
+++ b/Targets/FullCarKit/Sources/Network/Method.swift
@@ -1,0 +1,19 @@
+//
+//  JHRequest.swift
+//  todayMovie
+//
+//  Created by 한상진 on 11/20/23.
+//
+
+import Foundation
+
+public typealias Parameters = [String: Any]
+
+@frozen public enum HTTPMethod: String {
+    case get = "GET"
+    case head = "HEAD"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+}

--- a/Targets/FullCarKit/Sources/Network/NetworkError.swift
+++ b/Targets/FullCarKit/Sources/Network/NetworkError.swift
@@ -1,0 +1,62 @@
+//
+//  NetworkError.swift
+//  todayMovie
+//
+//  Created by 한상진 on 11/20/23.
+//
+
+import Foundation
+
+@frozen public enum NetworkError: Error {
+    case invalidURL(URLConvertible)
+    case endpointCongifureFailed
+    case parameterEnocdingFailed(ParameterEncoding)
+    case invalidResponse(Response)
+    case invalidSession(Session)
+}
+
+extension NetworkError {
+    public enum ParameterEncoding: Error {
+        case missingURL
+        case invalidJSON
+        case jsonEncodingFailed
+    }
+}
+
+extension NetworkError {
+    public enum Decoding: Error {
+        case failed
+        case dataIsNil
+    }
+}
+
+extension NetworkError {
+    public enum Response: Error {
+        case cancelled
+        case unhandled(error: Error?)
+        case invalidStatusCode(code: Int)
+        
+        init(statusCode: Int, error: Error?) {
+            if statusCode == 500 {
+                self = .invalidStatusCode(code: statusCode)
+            } else {
+                self = .unhandled(error: error)
+            }
+        }
+    }
+}
+
+extension NetworkError {
+    /// 현재는 사용할 일 x
+    public enum Session: Error {
+        case invalidSession
+        case invalidToken
+        case updateRequired
+    }
+}
+
+extension NetworkError {
+    static func isNetworkError(_ error: Error) -> Bool {
+        return (error as NSError).domain == "NSURLErrorDomain"
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/NetworkRequestable.swift
+++ b/Targets/FullCarKit/Sources/Network/NetworkRequestable.swift
@@ -1,0 +1,116 @@
+//
+//  DataRequest.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public struct NetworkResponse {
+    public let data: Data?
+    public let response: URLResponse?
+    public let error: Error?
+    
+    public init(data: Data?, response: URLResponse?, error: Error?) {
+        self.data = data
+        self.response = response
+        self.error = error
+    }
+}
+
+
+public protocol NetworkRequestable {
+    var session: URLSession { get }
+    var task: URLSessionTask? { get }
+    var options: NetworkRequestOptions { get }
+    var endpoint: URLRequestConfigurable { get }
+    var interceptors: [NetworkInterceptor] { get }
+    
+    func response<Model: Decodable>(with decoder: JSONDecoder) async throws -> Model
+    
+    func adapt(request: URLRequest) async throws -> URLRequest
+    func retry(
+        request: URLRequest,
+        response: URLResponse,
+        data: Data?,
+        error: Error
+    ) async -> (URLRequest, RetryResult)
+    func decode<Model: Decodable>(with decoder: JSONDecoder, response: NetworkResponse) throws -> Model
+    func validate(response: NetworkResponse) throws
+    func cancel() -> Self
+} 
+
+public extension NetworkRequestable {
+    func adapt(request: URLRequest) async throws -> URLRequest {
+        var urlRequest = request
+        for interceptor in interceptors {
+            urlRequest = try await interceptor.adapt(urlRequest: urlRequest, options: options)
+        }
+        return urlRequest
+    }
+    func retry(
+        request: URLRequest,
+        response: URLResponse,
+        data: Data?,
+        error: Error
+    ) async -> (URLRequest, RetryResult) {
+        var urlRequest = request
+        var retryResult = RetryResult.doNotRetry(with: error)
+        
+        for interceptor in interceptors {
+            if case RetryResult.doNotRetry(let error) = retryResult {
+                (urlRequest, retryResult) = await interceptor.retry(
+                    urlRequest: urlRequest, 
+                    response: response, 
+                    data: data, 
+                    with: error, 
+                    options: options
+                )
+            } else {
+                return (urlRequest, RetryResult.retry)
+            }
+        }
+        return (urlRequest, retryResult)    
+    }
+    func decode<Model: Decodable>(
+        with decoder: JSONDecoder,
+        response: NetworkResponse
+    ) throws -> Model {
+        if let data = response.data {
+            #if DEBUG
+            print("receive raw data\n\(String(data: data, encoding: .utf8) ?? "")")
+            #endif
+            if let success = try? decoder.decode(Model.self, from: data) {
+                return success
+            } else {
+                throw NetworkError.Decoding.failed
+            }
+        } else {
+            throw NetworkError.Decoding.dataIsNil
+        }
+    }
+    
+    func validate(response: NetworkResponse) throws {
+        guard let httpResponse = response.response as? HTTPURLResponse else {
+            throw NetworkError.Response.unhandled(error: response.error)
+        }
+        
+        guard httpResponse.isValidateStatus() else {
+            throw NetworkError.Response.invalidStatusCode(code: httpResponse.statusCode)
+        }
+    }
+    
+    @discardableResult
+    func cancel() -> Self {
+        task?.cancel()
+        return self
+    }
+}
+
+extension HTTPURLResponse {
+    fileprivate func isValidateStatus() -> Bool {
+        return (200..<300).contains(statusCode)
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/ParameterEncoding.swift
+++ b/Targets/FullCarKit/Sources/Network/ParameterEncoding.swift
@@ -1,0 +1,56 @@
+//
+//  ParameterEncoding.swift
+//  todayMovie
+//
+//  Created by 한상진 on 11/20/23.
+//
+
+import Foundation
+
+public protocol ParameterEncodable {
+    func encode(
+        request: URLRequest,
+        with parameters: Parameters?
+    ) throws -> URLRequest
+}
+
+public struct URLEncoding: ParameterEncodable {
+    public func encode(
+        request: URLRequest,
+        with parameters: Parameters?
+    ) throws -> URLRequest {
+        var request = request
+        guard let parameters else { return request }
+        guard let url = request.url else {
+            throw NetworkError.parameterEnocdingFailed(.missingURL)
+        }
+        if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            urlComponents.queryItems = parameters.compactMap { key, value in
+                return URLQueryItem(name: key, value: "\(value)")
+            }
+            request.url = urlComponents.url 
+        }
+        return request
+    }
+}
+
+public struct JSONEncoding: ParameterEncodable {
+    public func encode(
+        request: URLRequest,
+        with parameters: Parameters?
+    ) throws -> URLRequest {
+        var request = request
+        guard let parameters else { return request }
+        guard JSONSerialization.isValidJSONObject(parameters) else {
+            throw NetworkError.parameterEnocdingFailed(.invalidJSON)
+        }
+        do {
+            let data: Data = try JSONSerialization.data(withJSONObject: parameters)
+            request.httpBody = data
+        }
+        catch {
+            throw NetworkError.parameterEnocdingFailed(.jsonEncodingFailed)
+        }
+        return request
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/RequestOptions.swift
+++ b/Targets/FullCarKit/Sources/Network/RequestOptions.swift
@@ -1,0 +1,29 @@
+//
+//  RequestOptions.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public enum RetryResult {
+    case retry
+    case doNotRetry(with: Error)
+}
+
+public struct NetworkRequestOptions: OptionSet {
+    public let rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    public static let all: NetworkRequestOptions = [.refreshToken, .kickout, .forceUpdate]
+    public static let none: NetworkRequestOptions = []
+    public static let doNotRefreshToken: NetworkRequestOptions = [.kickout, .forceUpdate]
+    public static let refreshToken = NetworkRequestOptions(rawValue: 1 << 0)
+    public static let kickout = NetworkRequestOptions(rawValue: 1 << 1)
+    public static let forceUpdate = NetworkRequestOptions(rawValue: 1 << 2)
+}

--- a/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
+++ b/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dependencies
 
-struct TokenStorage {
+actor TokenStorage {
     static let key = "accountCredential"
 
     func save(token: AccountCredential) {

--- a/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
+++ b/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
@@ -1,0 +1,47 @@
+//
+//  TokenStorage.swift
+//  FullCarKit
+//
+//  Created by Sunny on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+struct TokenStorage {
+    // 토큰의 key값
+    private let key = "accountCredential"
+
+    func save(token: AccountCredential) {
+        let encoder = JSONEncoder()
+        guard let token = try? encoder.encode(token) else { return }
+
+        Keychain.shared.set(token, forKey: key)
+    }
+
+    func loadToken() -> AccountCredential? {
+        let decoder = JSONDecoder()
+        guard let data = Keychain.shared.getData(key),
+              let credential = try? decoder.decode(AccountCredential.self, from: data) else {
+            return nil
+        }
+
+        return credential
+    }
+
+    func deleteToken() {
+        Keychain.shared.delete(key)
+    }
+}
+
+extension DependencyValues {
+    var tokenStorage: TokenStorage {
+        get { self[TokenStorage.self] }
+        set { self[TokenStorage.self] = newValue }
+    }
+}
+
+extension TokenStorage: DependencyKey {
+    static var liveValue: TokenStorage = .init()
+}

--- a/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
+++ b/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
@@ -10,21 +10,20 @@ import Foundation
 import Dependencies
 
 struct TokenStorage {
-    // 토큰의 key값
-    private let key = "accountCredential"
+    static let key = "accountCredential"
 
     func save(token: AccountCredential) {
         let encoder = JSONEncoder()
         guard let token = try? encoder.encode(token) else { return }
 
-        self.deleteToken()
+        deleteToken()
 
-        Keychain.shared.set(token, forKey: key)
+        Keychain.shared.set(token, forKey: TokenStorage.key)
     }
 
     func loadToken() -> AccountCredential? {
         let decoder = JSONDecoder()
-        guard let data = Keychain.shared.getData(key),
+        guard let data = Keychain.shared.getData(TokenStorage.key),
               let credential = try? decoder.decode(AccountCredential.self, from: data) else {
             return nil
         }
@@ -33,7 +32,7 @@ struct TokenStorage {
     }
 
     func deleteToken() {
-        Keychain.shared.delete(key)
+        Keychain.shared.delete(TokenStorage.key)
     }
 }
 

--- a/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
+++ b/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
@@ -12,6 +12,10 @@ import Dependencies
 actor TokenStorage {
     static let key = "accountCredential"
 
+    enum TokenStorageError: Error {
+        case accountCredentialNil
+    }
+
     func save(token: AccountCredential) {
         let encoder = JSONEncoder()
         guard let token = try? encoder.encode(token) else { return }
@@ -21,11 +25,11 @@ actor TokenStorage {
         Keychain.shared.set(token, forKey: TokenStorage.key)
     }
 
-    func loadToken() -> AccountCredential? {
+    func loadToken() throws -> AccountCredential {
         let decoder = JSONDecoder()
         guard let data = Keychain.shared.getData(TokenStorage.key),
               let credential = try? decoder.decode(AccountCredential.self, from: data) else {
-            return nil
+            throw TokenStorageError.accountCredentialNil
         }
 
         return credential

--- a/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
+++ b/Targets/FullCarKit/Sources/Network/Token/TokenStorage.swift
@@ -17,6 +17,8 @@ struct TokenStorage {
         let encoder = JSONEncoder()
         guard let token = try? encoder.encode(token) else { return }
 
+        self.deleteToken()
+
         Keychain.shared.set(token, forKey: key)
     }
 

--- a/Targets/FullCarKit/Sources/Network/URLConvertible.swift
+++ b/Targets/FullCarKit/Sources/Network/URLConvertible.swift
@@ -1,0 +1,44 @@
+//
+//  URLConvertible.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public protocol URLRequestConvertible {
+    func asURLRequest() throws -> URLRequest
+}
+
+public protocol URLConvertible {
+    func asURL() throws -> URL
+}
+
+extension String: URLConvertible {
+    public func asURL() throws -> URL {
+        guard let url = URL(string: self) else { throw NetworkError.invalidURL(self) }
+        return url
+    } 
+}
+
+extension URL: URLConvertible {
+    public func asURL() throws -> URL { return self }
+}
+
+public struct DataRequestConvertor: URLRequestConvertible {
+    let url: URLConvertible
+    let method: HTTPMethod
+    let parameters: Parameters?
+    let encoding: ParameterEncodable
+    let headers: [Header]?
+    
+    public func asURLRequest() throws -> URLRequest {
+        var request = try URLRequest(url: url.asURL())
+        request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = headers?.dictionary
+        
+        return try encoding.encode(request: request, with: parameters)
+    }
+}

--- a/Targets/FullCarKit/Sources/Network/URLRequestConfigurable.swift
+++ b/Targets/FullCarKit/Sources/Network/URLRequestConfigurable.swift
@@ -1,0 +1,28 @@
+//
+//  URLRequestConfigurable.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/18/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public protocol URLRequestConfigurable {
+    var url: URLConvertible { get }
+    var path: String? { get }
+    var method: HTTPMethod { get }
+    var parameters: Parameters? { get }
+    var headers: [Header]? { get }
+    var encoder: ParameterEncodable { get }
+    func asURLRequest() throws -> URLRequest
+}
+
+extension URLRequestConfigurable {
+    public func asURLRequest() throws -> URLRequest {
+        var request = try URLRequest(url: url.asURL())
+        request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = headers?.dictionary
+        return try encoder.encode(request: request, with: parameters)
+    }
+}

--- a/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
@@ -15,25 +15,37 @@ public extension Endpoint {
 
     enum Account {
         case login(accessToken: String)
+        case logout
+        case leave
+        case refresh(accessToken: String, refreshToken: String)
     }
 }
 
 extension Endpoint.Account: URLRequestConfigurable {
     public var url: URLConvertible {
         switch self {
-        case .login(let accessToken): return "https://www.test.com"
+        case .login: return "https://www.test.com"
+        case .logout: return "https://www.test.com"
+        case .leave: return "https://www.test.com"
+        case .refresh: return "https://www.test.com"
         }
     }
     
     public var path: String? {
         switch self {
         case .login: return "/login"
+        case .logout: return "/logout"
+        case .leave: return "/leave"
+        case .refresh: return "/refresh"
         }
     }
     
     public var method: HTTPMethod {
         switch self {
         case .login: return .post
+        case .logout: return .post
+        case .leave: return .post
+        case .refresh: return .post
         }
     }
     
@@ -42,18 +54,30 @@ extension Endpoint.Account: URLRequestConfigurable {
         case .login(let accessToken): return [
             "accessToken": "\(accessToken)"
         ]
+        case .logout: return nil
+        case .leave: return nil
+        case .refresh(accessToken: let accessToken, refreshToken: let refreshToken): return [
+            "accessToken": "\(accessToken)",
+            "refreshToken": "\(refreshToken)"
+        ]
         }
     }
     
     public var headers: [Header]? {
         switch self {
         case .login: return nil
+        case .logout: return nil
+        case .leave: return nil
+        case .refresh: return nil
         }
     }
     
     public var encoder: ParameterEncodable {
         switch self {
         case .login: return JSONEncoding()
+        case .logout: return URLEncoding()
+        case .leave: return URLEncoding()
+        case .refresh: return JSONEncoding()
         }
     }
 }

--- a/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
@@ -12,6 +12,50 @@ public extension Endpoint {
     enum Home {
         case fetch(id: String, name: String)
     }
+
+    enum Account {
+        case login(accessToken: String)
+    }
+}
+
+extension Endpoint.Account: URLRequestConfigurable {
+    public var url: URLConvertible {
+        switch self {
+        case .login(let accessToken): return "https://www.test.com"
+        }
+    }
+    
+    public var path: String? {
+        switch self {
+        case .login: return "/login"
+        }
+    }
+    
+    public var method: HTTPMethod {
+        switch self {
+        case .login: return .post
+        }
+    }
+    
+    public var parameters: Parameters? {
+        switch self {
+        case .login(let accessToken): return [
+            "accessToken": "\(accessToken)"
+        ]
+        }
+    }
+    
+    public var headers: [Header]? {
+        switch self {
+        case .login: return nil
+        }
+    }
+    
+    public var encoder: ParameterEncodable {
+        switch self {
+        case .login: return JSONEncoding()
+        }
+    }
 }
 
 extension Endpoint.Home: URLRequestConfigurable {

--- a/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
@@ -1,0 +1,56 @@
+//
+//  Endpoint.swift
+//  todayMovie
+//
+//  Created by 한상진 on 11/20/23.
+//
+
+import Foundation
+
+public struct Endpoint { }
+public extension Endpoint {
+    enum Home {
+        case fetch(id: String, name: String)
+    }
+}
+
+extension Endpoint.Home: URLRequestConfigurable {
+    public var url: URLConvertible {
+        switch self {
+        case .fetch: return "https://www.naver.com"
+        }
+    }
+    
+    public var path: String? {
+        switch self {
+        case .fetch: return ""
+        }
+    }
+    
+    public var method: HTTPMethod {
+        switch self {
+        case .fetch: return .get
+        }
+    }
+    
+    public var parameters: Parameters? {
+        switch self {
+        case .fetch(let id, let name): return [
+            "id": "\(id)",
+            "name": "\(name)"
+        ]
+        }
+    }
+    
+    public var headers: [Header]? {
+        switch self {
+        case .fetch: return nil
+        }
+    }
+    
+    public var encoder: ParameterEncodable {
+        switch self {
+        case .fetch: return URLEncoding()
+        }
+    }
+}

--- a/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Endpoint.swift
@@ -17,7 +17,7 @@ public extension Endpoint {
         case login(accessToken: String)
         case logout
         case leave
-        case refresh(accessToken: String, refreshToken: String)
+        case refresh(refreshToken: String)
     }
 }
 
@@ -56,8 +56,7 @@ extension Endpoint.Account: URLRequestConfigurable {
         ]
         case .logout: return nil
         case .leave: return nil
-        case .refresh(accessToken: let accessToken, refreshToken: let refreshToken): return [
-            "accessToken": "\(accessToken)",
+        case .refresh(refreshToken: let refreshToken): return [
             "refreshToken": "\(refreshToken)"
         ]
         }

--- a/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Dependencies
 
 struct ErrorInterceptor: NetworkInterceptor {
     func adapt(urlRequest: URLRequest, options: NetworkRequestOptions) async throws -> URLRequest {
@@ -56,10 +57,12 @@ struct TokenInterceptor: NetworkInterceptor {
 
 extension TokenInterceptor {
     private func addToken(to urlRequest: URLRequest, for options: NetworkRequestOptions) async throws -> URLRequest {
-//        @Dependency(\.togetherAccount) var togetherAccount 
-//        var urlRequest = urlRequest
-//        let credential = try await togetherAccount.token()
-//        urlRequest.setHeader(.authorization("Bearer \(credential.xAuth)"))
+        @Dependency(\.tokenStorage) var tokenStorage
+
+        var urlRequest = urlRequest
+        let credential = try await tokenStorage.loadToken()
+
+        urlRequest.setHeaders([.authorization("Bearer \(credential.accessToken)")])
         return urlRequest
     }
 }

--- a/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
@@ -51,6 +51,8 @@ struct TokenInterceptor: NetworkInterceptor {
         with error: Error, 
         options: NetworkRequestOptions
     ) async -> (URLRequest, RetryResult) {
+        // 여기에 401 에러일때, refresh 호출하는 로직이 들어가야 하나?
+
         return (urlRequest, .doNotRetry(with: error))
     }
 }

--- a/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/Interceptors.swift
@@ -1,0 +1,92 @@
+//
+//  HeaderInterceptor.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorInterceptor: NetworkInterceptor {
+    func adapt(urlRequest: URLRequest, options: NetworkRequestOptions) async throws -> URLRequest {
+        return urlRequest
+    }
+    
+    func retry(
+        urlRequest: URLRequest, 
+        response: URLResponse?, 
+        data: Data?, 
+        with error: Error, 
+        options: NetworkRequestOptions
+    ) async -> (URLRequest, RetryResult) {
+        let mappedError = map(error: error, response: response, data: data)
+        // sessionError일 경우 kickout 해야하지만 현재 미구현
+        return (urlRequest, .doNotRetry(with: mappedError))
+    }
+}
+
+extension ErrorInterceptor {
+    private func map(error: Error, response: URLResponse?, data: Data?) -> Error {
+        if (error as NSError).code == NSURLErrorCancelled { return NetworkError.Response.cancelled }
+        if let networkError = error as? NetworkError { return networkError }
+        guard let httpResponse = response as? HTTPURLResponse else { return NetworkError.Response.unhandled(error: error) }
+        let statusCode = httpResponse.statusCode
+        // if let sessionError = SessionError(statusCode, error)
+        return NetworkError.Response(statusCode: statusCode, error: error)
+    }
+}
+
+struct TokenInterceptor: NetworkInterceptor {
+    func adapt(urlRequest: URLRequest, options: NetworkRequestOptions) async throws -> URLRequest {
+        let request = try await addToken(to: urlRequest, for: options)
+        return request
+    }
+    
+    func retry(
+        urlRequest: URLRequest, 
+        response: URLResponse?, 
+        data: Data?, 
+        with error: Error, 
+        options: NetworkRequestOptions
+    ) async -> (URLRequest, RetryResult) {
+        return (urlRequest, .doNotRetry(with: error))
+    }
+}
+
+extension TokenInterceptor {
+    private func addToken(to urlRequest: URLRequest, for options: NetworkRequestOptions) async throws -> URLRequest {
+//        @Dependency(\.togetherAccount) var togetherAccount 
+//        var urlRequest = urlRequest
+//        let credential = try await togetherAccount.token()
+//        urlRequest.setHeader(.authorization("Bearer \(credential.xAuth)"))
+        return urlRequest
+    }
+}
+
+
+struct HeaderInterceptor: NetworkInterceptor {
+    func adapt(urlRequest: URLRequest, options: NetworkRequestOptions) async throws -> URLRequest {
+        var urlRequest = urlRequest
+        urlRequest.setHeaders(Self.headers)
+        return urlRequest
+    }
+    
+    func retry(
+        urlRequest: URLRequest, 
+        response: URLResponse?, 
+        data: Data?, 
+        with error: Error, 
+        options: NetworkRequestOptions
+    ) async -> (URLRequest, RetryResult) {
+        return (urlRequest, .doNotRetry(with: error))
+    }
+}
+
+extension HeaderInterceptor {
+    static var headers: [Header] = {
+        var headers: [Header] = .init()
+        headers.append(.contentType(value: "application/json"))
+        return headers
+    }()
+}

--- a/Targets/FullCarKit/Sources/NetworkClient/NetworkClient.swift
+++ b/Targets/FullCarKit/Sources/NetworkClient/NetworkClient.swift
@@ -1,0 +1,50 @@
+//
+//  NetworkClient.swift
+//  FullCarKit
+//
+//  Created by 한상진 on 12/17/23.
+//  Copyright © 2023 FullCar Corp. All rights reserved.
+//
+
+import Foundation
+
+public struct NetworkClient {
+    private let session: URLSession
+    private var interceptors: [NetworkInterceptor]
+    
+    public init(
+        session: URLSession = .main,
+        interceptors: [NetworkInterceptor] = []
+    ) {
+        self.session = session
+        self.interceptors = interceptors
+    }
+    
+    public func request(
+        endpoint: URLRequestConfigurable,
+        interceptor: NetworkInterceptor? = nil
+    ) -> DataRequest {
+        var interceptors = self.interceptors
+        
+        if let interceptor {
+            interceptors.append(interceptor)
+        }
+        
+        return DataRequest(
+            session: session,
+            endpoint: endpoint,
+            interceptors: interceptors.reversed()
+        )
+    }
+}
+
+public extension URLSession {
+    static let main: URLSession = .init(configuration: .default)
+}
+
+public extension NetworkClient {
+    static let headerInterceptor: NetworkInterceptor = HeaderInterceptor()
+    static let tokenInterceptor: NetworkInterceptor = TokenInterceptor()
+    static let errorInterceptor: NetworkInterceptor = ErrorInterceptor()
+    static let main: NetworkClient = .init(session: .main, interceptors: [headerInterceptor, tokenInterceptor, errorInterceptor]) 
+}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -7,6 +7,7 @@ let dependencies = Dependencies(
             .firebase,
             .dependencies,
             .alamofire,
+            .kakao
         ],
         baseSettings: .settings(
             configurations: [


### PR DESCRIPTION
## 로그인 구현 

### 구현 내용
#### 로그인 객체 별 역할
- **FullCarKit/Sources/Account**
    - `API/AccountAPI` : 사용자 계정과 관련된 API 호출(네트워크 통신)
    - `Model/AccountCredential` : 자체 토큰 타입
    - `AccountService` : 사용자 계정 관리 역할
        - hasValidToken: 토큰이 존재하고, 기간이 유효한지 
        - login: 서버로 access token을 전달하고, 로그인에 성공하면 tokenStorage에 서비스 자체 토큰 타입인 AccountCredential 저장
        - logout: 로그아웃
        - leave: 회원 탈퇴 후 tokenStorage에서 토큰 삭제
- **FullCarKit/Sources/Network**
    - `Token/TokenStorage` : 서비스 자체 토큰인 AccountCredential을 Keychain으로 관리
- **FullCar/Sources/Login**
    - Login : 카카오/애플 로그인 구현
        - 클린 아키에서 Usecase와 같은 역할로 생각하고 구현함
  
 #### Kakao API 초기 설정
- Dependencies에 카카오 로그인 관련 SDK 추가
- 카카오 로그인 기본 설정을 위한 Info plist 수정
- 카카오 앱 키를 깃헙에 올리는 것을 막기 위한 xcconfig 설정
    - APIKeys 라는 xcconfig 파일을 생성해 FullCar/Resources 하위에 추가
    - .gitignore에 .xcconfig 추가
    - 키 값을 간편하게 가져오기 위한 Bundle extension 추가 

#### ViewModel에서 @Dependency 오류
- Property wrapper cannot be applied to a computed property 오류 발생
```swift
@MainActor
@Observable
final class LoginViewModel {
    @Dependency(\.login) var login
}
```
- @Observable는 모든 속성이 default value를 가져야 함.
- 해당 속성은 관찰할 필요가 없도록 @ObservationIgnored 추가해 오류 해결

### 궁금한 점
- 카카오 앱 키와 같은 API Key를 관리하는 APIKeys의 위치는 FullCar/Resources 하위에 있는 것이 적절한가요!?!!
- Swift-Dependencies 라이브러리를 사용한 의존성 관리는 처음인데 잘 사용한 것인지 확인 부탁드립니다,,,🙏

### 참고
- 애플 로그인을 실행하기 위해서는 Targets > Signing & Capabilities 에서 `Sign in with Apple` 옵션을 선택
- 저번에 하비가 옵션을 설정한 것 같았는데 다시 확인해보니 제 프로젝트 파일에서는 해당 옵션이 설정되어있지 않아 실행이 불가합니다,,
- 개발자 계정을 갖고 계신 분이라면 해당 설정 한번 부탁드리겠습니다ㅏ,,,